### PR TITLE
Ansible playbook for testing RHSCL containers in OCP4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: ocp4-tests
+
+ocp4-tests:
+	ansible-playbook deploy-and-test.yml

--- a/README.md
+++ b/README.md
@@ -1,18 +1,58 @@
 # Testing RHSCL containers on OpenShift 4.X
 
+We have several images in our GitHub namespace [https://github.com/sclorg/](https://github.com/sclorg/).
+We want to easy test all these images under an OpenShift 4.X environment and execute the basic use cases there
+whether those images running well in an OpenShift 4.X cluster (especially v4.3 and v4.4)
+
+The playboook `deploy-and-test`.yml perform these actions:
+- clone upstream image repository to `/tmp/rhscl_openshift_dir`
+- check if `vars` directory contains `<upstream_name>.yml` file
+- deploy an image specified in the `<upstream_name>.yml` file by variable `deployment`
+- test an image by variable `check_curl_output`
+- test and image by script defined in variable `test_exec_command` and check output defined by variable `expected_exec_result`
+
+## Tested containers
+
+Nowadays, we are able to test these containers:
+- s2i-nodejs-container
+- cakephp-ex
+- s2i-ruby-container
+- s2i-python-container
+- s2i-perl-container
+- httpd-container
+- postgresql-container
+- mysql-container
+- nginx-container
+
 ## Prerequisities
 
-before running playbook you have to do the following:
-1. export KUBEKONFIG like `export KUBECONFIG=<path_to_directory>/kubeconfig`
 
-## How to create a test for a new container
-In order to create a new test go through these steps.
-1. Go to directory `vars`
-1. Copy file `template-container.yml` to the new one, like `foobar.yml`
-1. Fill all variables in the file like, `deployment`, `pod_name`, `test_command`,
-`expected_results`, `test_command_2`, `expected_results_2`.
-1. Add the newest test info `deploy-and-test.yaml` file, task `Clone and test upstream container repositories`
-1. For more examples, see already existing tests
+### Install Fedora ansible-playbook package
+
+The tests are executed by `ansible-playbook` command. Install it by `dnf` command:
+```bash
+$ sudo dnf install -y ansible
+```
+
+### Download and install OpenShift Client 4
+
+To test RHSCL image under OpenShift 4.X environment you have to download
+at least OpenShift Client v4.3. The steps below will install the latest OpenShift Client 4 version.
+
+```bash
+$ mkdir -p ~/ocp4-client
+$ curl -o ~/ocp4-client/ocp4-client.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/latest-4.4/openshift-client-linux.tar.gz
+$ tar -xzvf ~/ocp4-client.tar.gz
+$ export PATH="${HOME}/ocp4-client:${PATH}"
+```
+
+### Set KUBECONFIG
+
+Before running playbook you have to export KUBECONFIG variable, by a command:
+
+```bash
+export KUBECONFIG=<path_to_directory>/kubeconfig
+```
 
 ## Test RHSCL containers under OpenShift 4.X
 
@@ -23,3 +63,17 @@ or simply by make command:
 ```bash
 make ocp4-tests
 ```
+
+To test only one container, run it by a command:
+```bash
+make ocp4-tests GITHUB_REPO=<upstream_github_repo_name>
+```
+
+## How to create a test for a new container
+In order to create a new test go through these steps.
+1. Go to directory `vars`
+1. Copy file `template-container.yml` to the new one, like `foobar.yml`
+1. Fill all variables in the file like, `deployment`, `pod_name`, `test_command`,
+`expected_results`, `test_command_2`, `expected_results_2`.
+1. Add the newest test info `deploy-and-test.yaml` file, task `Clone and test upstream container repositories`
+1. For more examples, see already existing tests

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Testing RHSCL containers on OpenShift 4.X
+
+## Prerequisities
+
+before running playbook you have to do the following:
+1. export KUBEKONFIG like `export KUBECONFIG=<path_to_directory>/kubeconfig`
+
+## How to create a test for a new container
+In order to create a new test go through these steps.
+1. Go to directory `vars`
+1. Copy file `template-container.yml` to the new one, like `foobar.yml`
+1. Fill all variables in the file like, `deployment`, `pod_name`, `test_command`,
+`expected_results`, `test_command_2`, `expected_results_2`.
+1. Add the newest test info `deploy-and-test.yaml` file, task `Clone and test upstream container repositories`
+1. For more examples, see already existing tests
+
+## Test RHSCL containers under OpenShift 4.X
+
+Testing run by a command:
+ansible-playbook deploy-and-test.yml
+
+or simply by make command:
+```bash
+make ocp4-tests
+```

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+inventory: localhost

--- a/deploy-and-test.yml
+++ b/deploy-and-test.yml
@@ -1,0 +1,43 @@
+---
+- name: Test RHSCL container images on OpenShift 4.X
+  hosts: localhost
+  vars:
+    testing_dir: "/tmp/rhscl_openshift_dir"
+  tasks:
+    - name: Check temporary directory
+      block:
+        - name: Remove directory
+          file:
+            state: absent
+            path: "{{ testing_dir }}"
+        - name: Create temporary directory
+          file:
+            state: directory
+            path: "{{ testing_dir }}"
+
+    - block:
+      - name: Check if KUBECONFIG is defined
+        command: echo "$KUBECONFIG"
+        register: kube
+      - name: check if kubeconfig is set
+        assert:
+          that:
+          - kube.stdout != ""
+          msg: "KUBECONFIG is not defined"
+        changed_when: false
+      ignore_errors: no
+
+    - name: Clone and test upstream container repositories
+      include_tasks: ./tasks/clone_scl_repo.yml
+      loop:
+        - s2i-ruby-container
+        - s2i-python-container
+        - s2i-perl-container
+        - httpd-container
+        - postgresql-container
+        - mysql-container
+        - nginx-container
+        # The ImageStreamTag "nodejs:12" is invalid: from: Error resolving ImageStreamTag nodejs:12 in namespace openshift: unable to find latest tagged image
+        - s2i-nodejs-container
+        # The ImageStreamTag "php:7.3" is invalid: from: Error resolving ImageStreamTag php:7.3 in namespace openshift: unable to find latest tagged image
+        - cakephp-ex

--- a/deploy-and-test.yml
+++ b/deploy-and-test.yml
@@ -3,6 +3,7 @@
   hosts: localhost
   vars:
     testing_dir: "/tmp/rhscl_openshift_dir"
+    github_repo: "{{ lookup('env', 'GITHUB_REPO')}}"
   tasks:
     - name: Check temporary directory
       block:
@@ -30,6 +31,10 @@
     - name: Clone and test upstream container repositories
       include_tasks: ./tasks/clone_scl_repo.yml
       loop:
+        # The ImageStreamTag "nodejs:12" is invalid: from: Error resolving ImageStreamTag nodejs:12 in namespace openshift: unable to find latest tagged image
+        - s2i-nodejs-container
+        # The ImageStreamTag "php:7.3" is invalid: from: Error resolving ImageStreamTag php:7.3 in namespace openshift: unable to find latest tagged image
+        - cakephp-ex
         - s2i-ruby-container
         - s2i-python-container
         - s2i-perl-container
@@ -37,7 +42,10 @@
         - postgresql-container
         - mysql-container
         - nginx-container
-        # The ImageStreamTag "nodejs:12" is invalid: from: Error resolving ImageStreamTag nodejs:12 in namespace openshift: unable to find latest tagged image
-        - s2i-nodejs-container
-        # The ImageStreamTag "php:7.3" is invalid: from: Error resolving ImageStreamTag php:7.3 in namespace openshift: unable to find latest tagged image
-        - cakephp-ex
+      when: github_repo is not defined
+
+    - name: Clone and test only one upstream container repository
+      include_tasks: ./tasks/clone_scl_repo.yml
+      loop:
+        - "{{ github_repo }}"
+      when: github_repo is defined

--- a/files/check_mysql_container.sh
+++ b/files/check_mysql_container.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+POD_NAME="$1"
+EXPECTED_RESULT="$2"
+
+test -z "${POD_NAME}" && echo "'pod_name' variable is not defined in yml" && exit 1
+test -z "${EXPECTED_RESULT}" && echo "'expected_results' variable is not defined in yml" && exit 1
+
+OUTPUT=$(oc exec ${POD_NAME} -it -- /bin/sh -i -c MYSQL_PWD=pass mysql -h 127.0.0.1 -u user -D db -e 'SELECT 1' && echo FINE || echo WRONG)
+echo ${OUTPUT}
+if [ "${OUTPUT}" == "${EXPECTED_RESULT}" ]; then
+    exit 0
+fi
+exit 1

--- a/files/check_pod_running.sh
+++ b/files/check_pod_running.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+POD_NAME="$1"
+
+test -z "${POD_NAME}" && echo "pod_name variable is not defined in yml" && exit 1
+
+POD_RUNNING=$(oc get pods --no-headers -o custom-columns=NAME:.metadata.name,STATUS:.status.phase \
+            | grep -v "${POD_NAME}-1-build" | grep -v "${POD_NAME}-1-deploy" \
+            | grep "${POD_NAME}" | cut -d' ' -f 1)
+if [ x"${POD_RUNNING}" != "x" ]; then
+    echo ${POD_RUNNING}
+    exit 0
+fi
+exit 1

--- a/files/check_postgresql_container.sh
+++ b/files/check_postgresql_container.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+
+POD_NAME="$1"
+EXPECTED_RESULT="$2"
+
+test -z "${POD_NAME}" && echo "'pod_name' variable is not defined in yml" && exit 1
+test -z "${EXPECTED_RESULT}" && echo "'expected_results' variable is not defined in yml" && exit 1
+
+
+OUTPUT=$(oc exec ${POD_NAME} -i -t -- /usr/libexec/check-container && echo FINE || echo WRONG)
+echo ${OUTPUT}
+if [ "${OUTPUT}" == "${EXPECTED_RESULT}" ]; then
+    exit 0
+fi
+
+exit 1

--- a/tasks/clone_scl_repo.yml
+++ b/tasks/clone_scl_repo.yml
@@ -1,0 +1,48 @@
+- name: Check if container task {{ item }} exists
+  stat:
+    path: "./vars/{{ item }}.yml"
+  register: file_exists
+
+- name: Set directory with cloned container {{ item }}
+  set_fact:
+    scl_dir: "{{ testing_dir }}/{{ item }}"
+
+- block:
+  - name: Clone {{ item }} repository
+    git:
+      repo: 'https://github.com/sclorg/{{ item }}.git'
+      dest: "{{ scl_dir }}"
+      recursive: yes
+    changed_when: false
+
+  - name: Export environment variables for testing
+    include_vars:
+      file: ./vars/{{ item }}.yml
+      name: stuff
+
+  - name: Deploy testing container {{ item }} into openshift
+    include_tasks: ./openshift_deploy.yml
+
+  - name: Test container {{ item }} in OpenShift 4.3 environment
+    include_tasks: ./openshift_test.yml
+    when: (route_cmd is defined) and (cluster_name.rc == 0)
+
+  - name: Check oc get pods
+    command: oc get pods
+    register: oc_get_pods
+
+  - debug:
+      var: oc_get_pods.stdout_lines
+
+  - name: oc delete all
+    command: oc delete all,cm,secrets,pvc --all
+    changed_when: false
+
+
+  when: file_exists.stat.exists
+
+- name: Remove cloned repository {{ item }}
+  file:
+    state: absent
+    path: "{{ scl_dir }}"
+

--- a/tasks/openshift_deploy.yml
+++ b/tasks/openshift_deploy.yml
@@ -1,0 +1,30 @@
+- name: Deploying container {{ item }} into OpenShift 4.3 environment
+  block:
+  - name: Deploy {{ item }}
+    shell: "{{ stuff.deployment }}"
+    changed_when: false
+    register: deploy_cmd
+    ignore_errors: yes
+
+  - name: Check if POD {{ stuff.pod_name }} is running
+    shell: "./files/check_pod_running.sh {{ stuff.pod_name }}"
+    register: cluster_name
+    until: cluster_name.rc == 0
+    retries: 50
+    delay: 10
+    ignore_errors: true
+
+  - name: Expose route with name {{ stuff.pod_name }} for testing
+    shell: "oc expose svc/{{ stuff.pod_name }} --name={{ stuff.pod_name }}"
+    when: (stuff.add_route is defined) and (cluster_name.rc == 0)
+
+  - name: Check if POD {{ stuff.pod_name }} exposes route
+    shell: "oc get routes --no-headers -o custom-columns=HOST:.spec.host | grep {{ stuff.pod_name }}"
+    changed_when: false
+    register: route_cmd
+    until: route_cmd.rc == 0
+    retries: 10
+    delay: 10
+    when: cluster_name.rc == 0
+
+  when: file_exists.stat.exists

--- a/tasks/openshift_test.yml
+++ b/tasks/openshift_test.yml
@@ -1,0 +1,23 @@
+- block:
+  - name: Check curl command and failed if {{ stuff.check_curl_output }} not in the page content
+    uri:
+      url: "http://{{ route_cmd.stdout }}"
+      return_content: yes
+      status_code: 200
+    retries: 10
+    delay: 10
+    register: this
+    ignore_errors: yes
+    failed_when: "'{{ stuff.check_curl_output }}' not in this.content"
+    until: this.status == 200
+
+  - debug:
+      var: this
+
+  when: (stuff.check_curl_output is defined)
+
+- name: Running test in pod by oc exec
+  shell: "{{ stuff.test_exec_command}} {{ cluster_name.stdout }} '{{ stuff.expected_exec_result }}'"
+  ignore_errors: yes
+  when: (stuff.test_exec_command is defined)
+

--- a/vars/cakephp-ex.yml
+++ b/vars/cakephp-ex.yml
@@ -1,0 +1,3 @@
+deployment: "oc process -f https://raw.githubusercontent.com/sclorg/cakephp-ex/master/openshift/templates/cakephp.json | oc apply -f -"
+pod_name: "cakephp-example"
+check_curl_output: "Welcome to your CakePHP application on OpenShift"

--- a/vars/httpd-container.yml
+++ b/vars/httpd-container.yml
@@ -1,0 +1,3 @@
+deployment: "oc process -f https://raw.githubusercontent.com/sclorg/httpd-ex/master/openshift/templates/httpd.json | oc apply -f -"
+pod_name: "httpd-example"
+check_curl_output: "Welcome to your static httpd application"

--- a/vars/mysql-container.yml
+++ b/vars/mysql-container.yml
@@ -1,0 +1,12 @@
+deployment: "oc new-app mysql:8.0~https://github.com/sclorg/mysql-container.git \
+	--name my-mysql-rhel7 \
+	--context-dir=examples/extend-image \
+	--env MYSQL_OPERATIONS_USER=opuser \
+	--env MYSQL_OPERATIONS_PASSWORD=oppass \
+	--env MYSQL_DATABASE=opdb \
+	--env MYSQL_USER=user \
+	--env MYSQL_PASSWORD=pass"
+pod_name: "my-mysql-rhel7"
+add_route: true
+test_exec_command: "./files/check_mysql_container.sh"
+expected_exec_result: "FINE"

--- a/vars/nginx-container.yml
+++ b/vars/nginx-container.yml
@@ -1,0 +1,3 @@
+deployment: "oc process -f https://raw.githubusercontent.com/sclorg/nginx-ex/master/openshift/templates/nginx.json | oc apply -f -"
+pod_name: "nginx-example"
+check_curl_output: "Welcome to your static nginx application"

--- a/vars/postgresql-container.yml
+++ b/vars/postgresql-container.yml
@@ -1,0 +1,10 @@
+deployment: "oc new-app postgresql:10~https://github.com/sclorg/postgresql-container.git \
+      --name new-postgresql \
+      --context-dir examples/extending-image/ \
+      -e POSTGRESQL_USER=user \
+      -e POSTGRESQL_DATABASE=db \
+      -e POSTGRESQL_PASSWORD=password"
+pod_name: "new-postgresql"
+add_route: true
+test_exec_command: "./files/check_postgresql_container.sh"
+expected_exec_result: "FINE"

--- a/vars/s2i-nodejs-container.yml
+++ b/vars/s2i-nodejs-container.yml
@@ -1,0 +1,3 @@
+deployment: "oc process -f https://raw.githubusercontent.com/sclorg/nodejs-ex/master/openshift/templates/nodejs.json | oc apply -f -"
+pod_name: "nodejs-example"
+check_curl_output: "Welcome to your Node.js application on OpenShift"

--- a/vars/s2i-perl-container.yml
+++ b/vars/s2i-perl-container.yml
@@ -1,0 +1,4 @@
+deployment: "oc new-app perl:5.26~https://github.com/sclorg/s2i-perl-container.git --context-dir=5.26/test/sample-test-app/"
+pod_name: "s2i-perl-container"
+add_route: true
+check_curl_output: "Everything is fine"

--- a/vars/s2i-python-container.yml
+++ b/vars/s2i-python-container.yml
@@ -1,0 +1,4 @@
+deployment: "oc new-app python:3.6~https://github.com/sclorg/s2i-python-container.git --context-dir=3.6/test/setup-test-app/"
+pod_name: "s2i-python-container"
+add_route: true
+check_curl_output: "Hello from gunicorn WSGI application"

--- a/vars/s2i-ruby-container.yml
+++ b/vars/s2i-ruby-container.yml
@@ -1,0 +1,4 @@
+deployment: "oc new-app ruby:2.5~https://github.com/sclorg/s2i-ruby-container.git --context-dir=2.5/test/puma-test-app/"
+pod_name: "s2i-ruby-container"
+add_route: true
+check_curl_output: "Hello world"

--- a/vars/template-container.yml
+++ b/vars/template-container.yml
@@ -1,0 +1,32 @@
+# Command how to deploy container into OpenShift 4.X
+# e.g. oc process -f https://raw.githubusercontent.com/sclorg/cakephp-ex/master/openshift/templates/cakephp.json | oc apply -f -
+deployment: ""
+
+# How to container is named in OpenShift environment. The name will be used for check if POD is running.
+pod_name: "cakephp-example"
+
+# First testing command
+# curl -I <http://....> is http:// is automatically filed by the playbook.
+# The url is taken by command oc get route <pod_name>
+test_command: "curl -I"
+
+# expected_results from test_command
+# In this case is a header of `curl -I` command
+expected_results: "grep 'HTTP/1.1 200 OK'"
+
+# OPTIONAL
+# Second testing command
+# curl <http://....> is http:// is automatically filed by the playbook.
+# The url is taken by command oc get route <pod_name>
+test_command_2: "curl"
+
+# OPTIONAL
+# expected_results_2 from test_command_2
+# in this case out contains a string which is checked.
+expected_results_2: "grep 'Welcome to your CakePHP application on OpenShift'"
+
+# Testing command run in pod_name
+test_exec_command: '/usr/libexec/check-container && echo FINE || echo WRONG'
+
+# expected results from `test_exec_command`
+expected_exec_result: "grep 'FINE"


### PR DESCRIPTION
This playbook is used for testing RHSCL containers
in OCP4 environment.

Only, exporting KUBECONFIG is need for successful testing.

I have to verify in OCP4 cluster if ansible uri module works properly.
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>