### PR TITLE
Add support for mariadb-container and django-ex container

### DIFF
--- a/deploy-and-test.yml
+++ b/deploy-and-test.yml
@@ -31,9 +31,7 @@
     - name: Clone and test upstream container repositories
       include_tasks: ./tasks/clone_scl_repo.yml
       loop:
-        # The ImageStreamTag "nodejs:12" is invalid: from: Error resolving ImageStreamTag nodejs:12 in namespace openshift: unable to find latest tagged image
         - s2i-nodejs-container
-        # The ImageStreamTag "php:7.3" is invalid: from: Error resolving ImageStreamTag php:7.3 in namespace openshift: unable to find latest tagged image
         - cakephp-ex
         - s2i-ruby-container
         - s2i-python-container
@@ -41,11 +39,13 @@
         - httpd-container
         - postgresql-container
         - mysql-container
+        - mariadb-container
         - nginx-container
-      when: github_repo is not defined
+        - django-ex
+      when: github_repo == ""
 
     - name: Clone and test only one upstream container repository
       include_tasks: ./tasks/clone_scl_repo.yml
       loop:
         - "{{ github_repo }}"
-      when: github_repo is defined
+      when: (github_repo is defined) and (github_repo != "")

--- a/files/check_mariadb_container.sh
+++ b/files/check_mariadb_container.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+POD_NAME="$1"
+EXPECTED_RESULT="$2"
+
+test -z "${POD_NAME}" && echo "'pod_name' variable is not defined in yml" && exit 1
+test -z "${EXPECTED_RESULT}" && echo "'expected_results' variable is not defined in yml" && exit 1
+
+OUTPUT=$(oc exec ${POD_NAME} -it -- /bin/sh -i -c MYSQL_PWD=pass mysql -h 127.0.0.1 -u user -D db -e 'SELECT 1' && echo FINE || echo WRONG)
+echo ${OUTPUT}
+if [ "${OUTPUT}" == "${EXPECTED_RESULT}" ]; then
+    exit 0
+fi
+exit 1

--- a/tasks/clone_scl_repo.yml
+++ b/tasks/clone_scl_repo.yml
@@ -23,16 +23,25 @@
   - name: Deploy testing container {{ item }} into openshift
     include_tasks: ./openshift_deploy.yml
 
-  - name: Test container {{ item }} in OpenShift 4.3 environment
+  - name: Test container {{ item }} in OpenShift 4.5 environment
     include_tasks: ./openshift_test.yml
     when: (route_cmd is defined) and (cluster_name.rc == 0)
 
   - name: Check oc get pods
     command: oc get pods
     register: oc_get_pods
+    changed_when: false
 
   - debug:
       var: oc_get_pods.stdout_lines
+
+  - name: Check cluster status
+    command: oc status
+    register: oc_status
+    changed_when: false
+
+  - debug:
+      var: oc_status.stdout_lines
 
   - name: oc delete all
     command: oc delete all,cm,secrets,pvc --all
@@ -45,4 +54,5 @@
   file:
     state: absent
     path: "{{ scl_dir }}"
+  changed_when: false
 

--- a/tasks/openshift_test.yml
+++ b/tasks/openshift_test.yml
@@ -1,23 +1,38 @@
 - block:
-  - name: Check curl command and failed if {{ stuff.check_curl_output }} not in the page content
+  - name: Check curl command is working
     uri:
       url: "http://{{ route_cmd.stdout }}"
       return_content: yes
       status_code: 200
+      body_format: json
     retries: 10
     delay: 10
-    register: this
+    register: curl_output
     ignore_errors: yes
-    failed_when: "'{{ stuff.check_curl_output }}' not in this.content"
-    until: this.status == 200
+    until: curl_output.status == 200
 
-  - debug:
-      var: this
+  - name: Check proper output in json
+    debug:
+      var: curl_output
+
+  - fail:
+      msg: Output {{ stuff.check_curl_output }} is not present in curl command
+    when: '"{{ stuff.check_curl_output }}" not in curl_output["content"]'
 
   when: (stuff.check_curl_output is defined)
 
-- name: Running test in pod by oc exec
-  shell: "{{ stuff.test_exec_command}} {{ cluster_name.stdout }} '{{ stuff.expected_exec_result }}'"
-  ignore_errors: yes
+- block:
+  - name: Running test in pod by oc exec
+    shell: "{{ stuff.test_exec_command }} {{ cluster_name.stdout }} '{{ stuff.expected_exec_result }}'"
+    ignore_errors: yes
+    register: command_out
+    retries: 10
+    delay: 10
+    until: command_out.rc == 0
+
+  - fail:
+      msg: Command {{ stuff.test_exec_command }} {{ cluster_name.stdout }} '{{ stuff.expected_exec_result }}'
+    when: command_out.rc != 0
+
   when: (stuff.test_exec_command is defined)
 

--- a/vars/django-ex.yml
+++ b/vars/django-ex.yml
@@ -1,0 +1,3 @@
+deployment: "oc process -f https://raw.githubusercontent.com/sclorg/django-ex/master/openshift/templates/django.json | oc apply -f -"
+pod_name: "django-example"
+check_curl_output: "Welcome to your Django application on OpenShift"

--- a/vars/mariadb-container.yml
+++ b/vars/mariadb-container.yml
@@ -1,0 +1,12 @@
+deployment: "oc new-app mariadb:10.3~https://github.com/sclorg/mariadb-container.git \
+	--name my-mariadb-rhel7 \
+	--context-dir=examples/extend-image \
+	--env MYSQL_OPERATIONS_USER=opuser \
+	--env MYSQL_OPERATIONS_PASSWORD=oppass \
+	--env MYSQL_DATABASE=opdb \
+	--env MYSQL_USER=user \
+	--env MYSQL_PASSWORD=pass"
+pod_name: "my-mariadb-rhel7"
+add_route: true
+test_exec_command: "./files/check_mariadb_container.sh"
+expected_exec_result: "FINE"


### PR DESCRIPTION
This commit adds support for mariadb and django container.

It also fixes some troubles with failed tasks.
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>