### PR TITLE
add support for running playbooks on remote hosts

### DIFF
--- a/deploy-and-test.yml
+++ b/deploy-and-test.yml
@@ -1,6 +1,6 @@
 ---
 - name: Test RHSCL container images on OpenShift 4.X
-  hosts: localhost
+  hosts: "{{ hosts | default('localhost') }}"
   vars:
     testing_dir: "/tmp/rhscl_openshift_dir"
     github_repo: "{{ lookup('env', 'GITHUB_REPO')}}"

--- a/tasks/openshift_deploy.yml
+++ b/tasks/openshift_deploy.yml
@@ -24,6 +24,7 @@
     delay: 10
     ignore_errors: yes
     when: deploy_cmd.rc == 0
+    delegate_to: localhost
 
   - name: Expose route with name {{ stuff.pod_name }} for testing
     shell: "oc expose svc/{{ stuff.pod_name }} --name={{ stuff.pod_name }}"

--- a/tasks/openshift_test.yml
+++ b/tasks/openshift_test.yml
@@ -47,6 +47,7 @@
     retries: 10
     delay: 10
     until: command_out.rc == 0
+    delegate_to: localhost
 
   - name: Set test was not successful
     xml:

--- a/tasks/verify_in_openshift.yml
+++ b/tasks/verify_in_openshift.yml
@@ -2,12 +2,14 @@
   stat:
     path: "./vars/{{ item }}.yml"
   register: file_exists
+  delegate_to: localhost
 
 - block:
   - name: Export environment variables for testing
     include_vars:
       file: ./vars/{{ item }}.yml
       name: stuff
+    delegate_to: localhost
 
   - name: Set facts, scl dir and scl_ex_dir
     include_tasks: ./set_fact.yml


### PR DESCRIPTION
This change introduces compatibility to run the tests from either
localhost or a remote host defined as a variable.

This provides the benefit of being able to call this playbook from a machine without `oc` command or `KUBECONFIG` and run the tests on a remote host which has `oc` command and `KUBECONFIG` defined.

Tested this change for both a `host = localhost` and `host = remote-host` and tests successfully executed.

**Localhost** `ansible-playbook deploy-and-test.yml` (Default behavior)

**Remote Host** `ansible-playbook deploy-and-test.yml -e "hosts=<remote-host>"`