### PR TITLE
use script over shell module to properly run scripts on defined hosts

### DIFF
--- a/tasks/openshift_deploy.yml
+++ b/tasks/openshift_deploy.yml
@@ -17,14 +17,13 @@
         - deploy: "{{ deploy_cmd.rc }}"
 
   - name: Check if POD {{ stuff.pod_name }} is running
-    shell: "./files/check_pod_running.sh {{ stuff.pod_name }}"
+    script: "./files/check_pod_running.sh {{ stuff.pod_name }}"
     register: cluster_name
     until: cluster_name.rc == 0
     retries: 50
     delay: 10
     ignore_errors: yes
     when: deploy_cmd.rc == 0
-    delegate_to: localhost
 
   - name: Expose route with name {{ stuff.pod_name }} for testing
     shell: "oc expose svc/{{ stuff.pod_name }} --name={{ stuff.pod_name }}"

--- a/tasks/openshift_test.yml
+++ b/tasks/openshift_test.yml
@@ -41,13 +41,12 @@
 
 - block:
   - name: Running test in pod by oc exec
-    shell: "{{ stuff.test_exec_command }} {{ cluster_name.stdout }} '{{ stuff.expected_exec_result }}'"
+    script: "{{ stuff.test_exec_command }} {{ cluster_name.stdout | trim }} '{{ stuff.expected_exec_result }}'"
     ignore_errors: yes
     register: command_out
     retries: 10
     delay: 10
     until: command_out.rc == 0
-    delegate_to: localhost
 
   - name: Set test was not successful
     xml:


### PR DESCRIPTION
To fully support the playbook to run on non localhosts, the tasks
calling the shell scripts under files/ will need to use the script
module. Without this, the prior delegate_to will continue to run
always on localhost.

Also trims any new lines on the pod name when running tests using
oc exec. Without this when using script module, the second parameter
to the script was never being found.

An example run output for `postgresql-container` using script module but without trimming newlines:

```
TASK [cluster] *************************************************************************************************************************************************************************************************************************
ok: [x.x.x.x] => {
    "msg": "new-postgresql-6778d6dcd-l4j25\r\n"
}

TASK [Running test in pod by oc exec] **************************************************************************************************************************************************************************************************
FAILED - RETRYING: Running test in pod by oc exec (10 retries left).
FAILED - RETRYING: Running test in pod by oc exec (9 retries left).
FAILED - RETRYING: Running test in pod by oc exec (8 retries left).
FAILED - RETRYING: Running test in pod by oc exec (7 retries left).
FAILED - RETRYING: Running test in pod by oc exec (6 retries left).
FAILED - RETRYING: Running test in pod by oc exec (5 retries left).
FAILED - RETRYING: Running test in pod by oc exec (4 retries left).
FAILED - RETRYING: Running test in pod by oc exec (3 retries left).
FAILED - RETRYING: Running test in pod by oc exec (2 retries left).
FAILED - RETRYING: Running test in pod by oc exec (1 retries left).
fatal: [x.x.x.x]: FAILED! => {"attempts": 10, "changed": true, "msg": "non-zero return code", "rc": 127, "stderr": "Shared connection to x.x.x.x closed.\r\n", "stderr_lines": ["Shared connection to x.x.x.x closed."], "stdout": "'expected_results' variable is not defined in yml\r\n/bin/sh: line 1: FINE: command not found\r\n", "stdout_lines": ["'expected_results' variable is not defined in yml", "/bin/sh: line 1: FINE: command not found"]}
...ignoring
```

With trimming new line the console output is observed:

```
TASK [cluster] *************************************************************************************************************************************************************************************************************************
ok: [x.x.x.x] => {
    "msg": "new-postgresql-9fb6bbcdf-g5xgv"
}

TASK [Running test in pod by oc exec] **************************************************************************************************************************************************************************************************
changed: [x.x.x.x] => {"attempts": 1, "changed": true, "rc": 0, "stderr": "Shared connection to x.x.x.x closed.\r\n", "stderr_lines": ["Shared connection to x.x.x.x closed."], "stdout": "FINE\r\n", "stdout_lines": ["FINE"]}
```