### PR TITLE
update xunit file generation to be compatible with most xunit parser libraries

### DIFF
--- a/deploy-and-test.yml
+++ b/deploy-and-test.yml
@@ -6,6 +6,8 @@
     github_repo: "{{ lookup('env', 'GITHUB_REPO')}}"
     xml_file_name: "rhscl-testing-results.xml"
     xml_file: "{{ testing_dir }}/{{ xml_file_name }}"
+    xml_testsuite_path: "/testsuite"
+    xml_testcase_path: "{{ xml_testsuite_path }}/testcase"
   tasks:
     - name: Check temporary directory and create XML unit file
       block:

--- a/tasks/clone_scl_repo.yml
+++ b/tasks/clone_scl_repo.yml
@@ -5,17 +5,11 @@
     recursive: yes
   changed_when: false
 
-- name: Set new child
+- name: Write test case element
   xml:
     path: "{{ xml_file }}"
-    xpath: /rhscl-testing/testsuite
+    xpath: "{{ xml_testsuite_path }}"
     pretty_print: yes
     add_children:
-      - testcase: ""
-- name: Set name
-  xml:
-    path: "{{ xml_file }}"
-    xpath: /rhscl-testing/testsuite/testcase
-    pretty_print: yes
-    add_children:
-      - name: "{{ stuff.scl_url }}"
+      - testcase:
+          name: "{{ stuff.scl_url }}"

--- a/tasks/openshift_deploy.yml
+++ b/tasks/openshift_deploy.yml
@@ -8,14 +8,6 @@
 
   - debug: var=deploy_cmd
 
-  - name: Set deploy was successful
-    xml:
-      path: "{{ xml_file }}"
-      xpath: '/rhscl-testing/testsuite/testcase'
-      pretty_print: yes
-      add_children:
-        - deploy: "{{ deploy_cmd.rc }}"
-
   - name: Check if POD {{ stuff.pod_name }} is running
     script: "./files/check_pod_running.sh {{ stuff.pod_name }}"
     register: cluster_name

--- a/tasks/openshift_test.yml
+++ b/tasks/openshift_test.yml
@@ -15,26 +15,32 @@
     debug:
       var: curl_output
 
-  - name: Set test was not successful
-    xml:
-      path: "{{ xml_file }}"
-      xpath: '/rhscl-testing/testsuite/testcase'
-      pretty_print: yes
-      add_children:
-        - test_result: "1"
-        - test_url: "{{ curl_output.url }}"
-        - test_msg: "{{ curl_output.msg }}"
+  - block:
+      - name: Write test case failure elements
+        xml:
+          path: "{{ xml_file }}"
+          xpath: "{{ xml_testcase_path }}"
+          pretty_print: yes
+          add_children:
+            - failure:
+                message: "Test failed"
+            - system-err: "{{ curl_output.msg | trim }}"
+
+      - name: Increment testsuite failures attribute
+        xml:
+          path: "{{ xml_file }}"
+          xpath: "{{ xml_testsuite_path }}"
+          attribute: failures
+          value: "{{ testsuite_attrs.failures|int + 1 }}"
     when: '"{{ stuff.check_curl_output }}" not in curl_output["content"]'
 
-  - name: Set test was successful
+  - name: Write test case passed elements
     xml:
       path: "{{ xml_file }}"
-      xpath: '/rhscl-testing/testsuite/testcase'
+      xpath: "{{ xml_testcase_path }}"
       pretty_print: yes
       add_children:
-        - test_result: "0"
-        - test_url: "{{ curl_output.url }}"
-        - test_msg: "{{ curl_output.msg }}"
+        - system-out: "{{ curl_output.msg | trim }}"
     when: '"{{ stuff.check_curl_output }}" in curl_output["content"]'
 
   when: (stuff.check_curl_output is defined)
@@ -48,26 +54,32 @@
     delay: 10
     until: command_out.rc == 0
 
-  - name: Set test was not successful
-    xml:
-      path: "{{ xml_file }}"
-      xpath: '/rhscl-testing/testsuite/testcase'
-      pretty_print: yes
-      add_children:
-        - test_result: "1"
-        - test_url: "{{ stuff.test_exec_command }}"
-        - test_msg: "{{ stuff.expected_exec_result }}"
+  - block:
+      - name: Write test case failure elements
+        xml:
+          path: "{{ xml_file }}"
+          xpath: "{{ xml_testcase_path }}"
+          pretty_print: yes
+          add_children:
+            - failure:
+                message: "Test failed"
+            - system-err: "{{ command_out.stderr | trim }}"
+
+      - name: Increment testsuite failures attribute
+        xml:
+          path: "{{ xml_file }}"
+          xpath: "{{ xml_testsuite_path }}"
+          attribute: failures
+          value: "{{ testsuite_attrs.failures|int + 1 }}"
     when: command_out.rc != 0
 
-  - name: Set test was successful
+  - name: Write test case passed elements
     xml:
       path: "{{ xml_file }}"
-      xpath: '/rhscl-testing/testsuite/testcase'
+      xpath: "{{ xml_testcase_path }}"
       pretty_print: yes
       add_children:
-        - test_result: "0"
-        - test_url: "{{ stuff.test_exec_command }}"
-        - test_msg: "{{ stuff.expected_exec_result }}"
+        - system-out: "{{ command_out.stdout | trim }}"
     when: command_out.rc == 0
 
   when: (stuff.test_exec_command is defined)

--- a/tasks/verify_in_openshift.yml
+++ b/tasks/verify_in_openshift.yml
@@ -14,6 +14,16 @@
   - name: Set facts, scl dir and scl_ex_dir
     include_tasks: ./set_fact.yml
 
+  - name: Get testsuite attributes
+    xml:
+      path: "{{ xml_file }}"
+      xpath: "{{ xml_testsuite_path }}"
+      content: attribute
+    register: testsuite_attributes
+
+  - name: Set fact for testsuite attributes
+    set_fact:
+      testsuite_attrs: "{{ testsuite_attributes.matches[0].testsuite }}"
 
   - name: Clone upstream repo
     include_tasks: ./clone_scl_repo.yml
@@ -25,14 +35,31 @@
     include_tasks: ./openshift_test.yml
     when: (route_cmd is defined) and (deploy_cmd.rc == 0) and (cluster_name.rc == 0)
 
-  - name: Write status of test
+  - block:
+      - name: Write test case error elements
+        xml:
+          path: "{{ xml_file }}"
+          xpath: "{{ xml_testcase_path }}"
+          pretty_print: yes
+          add_children:
+            - error:
+                message: "Container deployment failed"
+            - system-err: "{{ deploy_cmd.stderr | trim }}"
+
+      - name: Increment testsuite errors attribute
+        xml:
+          path: "{{ xml_file }}"
+          xpath: "{{ xml_testsuite_path }}"
+          attribute: errors
+          value: "{{ testsuite_attrs.errors|int + 1 }}"
+    when: deploy_cmd.rc != 0
+
+  - name: Increment testsuite tests attribute
     xml:
       path: "{{ xml_file }}"
-      xpath: '/rhscl-testing/testsuite/testcase'
-      pretty_print: yes
-      add_children:
-        - test_result: "1"
-    when: deploy_cmd.rc != 0
+      xpath: "{{ xml_testsuite_path }}"
+      attribute: tests
+      value: "{{ testsuite_attrs.tests|int + 1 }}"
 
   - name: Check oc get pods
     command: oc get pods

--- a/vars/rhscl-testing-results.xml
+++ b/vars/rhscl-testing-results.xml
@@ -1,5 +1,3 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<rhscl-testing>
-    <testsuite>
-    </testsuite>
-</rhscl-testing>
+<testsuite name="rhscl-tests" errors="0" failures="0" skipped="0" tests="0">
+</testsuite>


### PR DESCRIPTION
This PR brings updates to the xUnit result file generated. The current file generated is not compatible with the xunit parser plugin in Jenkins and other parser libraries written in Python. This change will include the necessary elements for each test case depending on whether the test case was passed, failed or error status.

For passed test cases, the `system-out` element is added, for failed test cases, the `system-err`/`failure` elements are added and for error test cases, the `system-err`/`error` elements are added. Each test case element will include the `name` attribute defining the test case name.

The `testsuite` element contains new attributes for defining the total number of tests that have run, skipped, failures and errors.

The example xUnit file below is for a full run with all tests passing:

```xml
<?xml version='1.0' encoding='UTF-8'?>
<testsuite name="rhscl-tests" errors="0" failures="0" skipped="0" tests="11">
  <testcase name="nodejs-ex">
    <system-out>OK (40430 bytes)</system-out>
  </testcase>
  <testcase name="cakephp-ex">
    <system-out>OK (unknown bytes)</system-out>
  </testcase>
  <testcase name="s2i-ruby-container">
    <system-out>OK (12 bytes)</system-out>
  </testcase>
  <testcase name="s2i-python-container">
    <system-out>OK (unknown bytes)</system-out>
  </testcase>
  <testcase name="s2i-perl-container">
    <system-out>OK (unknown bytes)</system-out>
  </testcase>
  <testcase name="httpd-container">
    <system-out>OK (37451 bytes)</system-out>
  </testcase>
  <testcase name="postgresql-container">
    <system-out>FINE</system-out>
  </testcase>
  <testcase name="mysql-container">
    <system-out>FINE</system-out>
  </testcase>
  <testcase name="mariadb-container">
    <system-out>FINE</system-out>
  </testcase>
  <testcase name="nginx-container">
    <system-out>OK (37451 bytes)</system-out>
  </testcase>
  <testcase name="django-ex">
    <system-out>OK (18500 bytes)</system-out>
  </testcase>
</testsuite>
~                
```

The example xUnit file below is for a full run with tests passing/failing (failures were forced no issue with container image):

```xml
<?xml version='1.0' encoding='UTF-8'?>
<testsuite name="rhscl-tests" errors="0" failures="3" skipped="0" tests="11">
  <testcase name="nodejs-ex">
    <failure message="Test failed"/>
    <system-err>OK (40430 bytes)</system-err>
  </testcase>
  <testcase name="cakephp-ex">
    <system-out>OK (unknown bytes)</system-out>
  </testcase>
  <testcase name="s2i-ruby-container">
    <failure message="Test failed"/>
    <system-err>OK (12 bytes)</system-err>
  </testcase>
  <testcase name="s2i-python-container">
    <system-out>OK (unknown bytes)</system-out>
  </testcase>
  <testcase name="s2i-perl-container">
    <system-out>OK (unknown bytes)</system-out>
  </testcase>
  <testcase name="httpd-container">
    <system-out>OK (37451 bytes)</system-out>
  </testcase>
  <testcase name="postgresql-container">
    <failure message="Test failed"/>
    <system-err>Unable to use a TTY - input is not a terminal or the right kind of file</system-err>
  </testcase>
  <testcase name="mysql-container">
    <system-out>FINE</system-out>
  </testcase>
  <testcase name="mariadb-container">
    <system-out>FINE</system-out>
  </testcase>
  <testcase name="nginx-container">
    <system-out>OK (37451 bytes)</system-out>
  </testcase>
  <testcase name="django-ex">
    <system-out>OK (18500 bytes)</system-out>
  </testcase>
</testsuite>
```

The example xUnit file below is for an error test case if container deployment fails:

```xml
<?xml version='1.0' encoding='UTF-8'?>
<testsuite name="rhscl-tests" errors="1" failures="0" skipped="0" tests="1">
  <testcase name="nodejs-ex">
    <error message="Container deployment failed"/>
    <system-err>error: failed to read input object (not a Template?): unable to recognize "https://raw.githubusercontent.com/sclorg/nodejs-ex/master/openshift/templates/nodejs.json": Unauthorized
error: no objects passed to apply</system-err>
  </testcase>
</testsuite>
```