### PR TITLE
Add dotnet test cases

### DIFF
--- a/README.ocp4
+++ b/README.ocp4
@@ -91,3 +91,16 @@ or simply by make command:
 make ocp4-tests EXT_TEST=verify_java
 ```
 
+## Test dotnet container by ansible-tests in OpenShift
+
+This repo can test Dotnet containers under OpenShift 4 as well.
+
+Testing run by a command:
+
+ansible-playbook deploy-and-test.yml -e ext_test=dotnet
+
+or simply by make command:
+```bash
+make ocp4-tests EXT_TEST=dotnet
+```
+

--- a/deploy-and-test.yml
+++ b/deploy-and-test.yml
@@ -50,12 +50,16 @@
         - rhel7-s2i-ruby-25-container
         - rhel7-s2i-python-36-container
         - rhel7-s2i-perl-526-container
+        - rhel7-dotnet21-container
+        - rhel7-dotnet31-container
         - rhel8-s2i-perl-526-container
         - rhel8-s2i-python-36-container
         #- rhel8-s2i-python-38-container Problem with deploying # error: the image match "python:3.8" for source repository "https://github.com/sclorg/s2i-python-container.git" does not appear to be a source-to-image builder.
         - rhel8-s2i-ruby-25-container
         #- rhel8-s2i-ruby-26-container Problem with deploying # error: the image match "ruby:2.6" for source repository "https://github.com/sclorg/s2i-ruby-container.git" does not appear to be a source-to-image builder.
         - rhel8-mysql-80-container
+        - rhel8-dotnet21-container
+        - rhel8-dotnet31-container
       when: github_repo == ""
 
     - name: Clone and test only one upstream container repository

--- a/deploy-and-test.yml
+++ b/deploy-and-test.yml
@@ -70,4 +70,13 @@
       loop:
         - java-8-container
         - java-11-container
-      when: (ext_test is defined) and (ext_test != "")
+      when: (ext_test is defined) and (ext_test == "verify_java")
+
+    - name: Check dotnet containers
+      include_tasks: ./tasks/verify_in_openshift.yml
+      loop:
+        - rhel7-dotnet21-container
+        - rhel7-dotnet31-container
+        - rhel8-dotnet21-container
+        - rhel8-dotnet31-container
+      when: (ext_test is defined) and (ext_test == "dotnet")

--- a/files/check_oc_exec_output.sh
+++ b/files/check_oc_exec_output.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+CMD="$1"
+shift
+POD_NAME="$1"
+shift
+EXPECTED_RESULT="$1"
+shift
+
+test -z "${CMD}" && echo "'cmd' variable is not defined in yml" && exit 1
+test -z "${POD_NAME}" && echo "'pod_name' variable is not defined in yml" && exit 1
+test -z "${EXPECTED_RESULT}" && echo "'expected_results' variable is not defined in yml" && exit 1
+
+OUTPUT=$(oc exec ${POD_NAME} "$@" -t -- /bin/bash -c "${CMD}")
+echo ${OUTPUT}
+if [ -z "${OUTPUT##*$EXPECTED_RESULT*}" ]; then
+        exit 0
+fi
+echo "EXPECTED RESULT NOT FOUND IN OUTPUT" 1>&2
+exit 1

--- a/tasks/clone_scl_repo.yml
+++ b/tasks/clone_scl_repo.yml
@@ -4,6 +4,7 @@
     dest: "{{ scl_dir }}"
     recursive: yes
   changed_when: false
+  when: (stuff.scl_url is defined)
 
 - name: Write test case element
   xml:

--- a/tasks/openshift_test.yml
+++ b/tasks/openshift_test.yml
@@ -23,7 +23,7 @@
           pretty_print: yes
           add_children:
             - failure:
-                message: "Test failed"
+                message: "Check curl Test failed"
             - system-err: "{{ curl_output.msg | trim }}"
 
       - name: Increment testsuite failures attribute
@@ -62,7 +62,7 @@
           pretty_print: yes
           add_children:
             - failure:
-                message: "Test failed"
+                message: "In Pod Test failed"
             - system-err: "{{ command_out.stderr | trim }}"
 
       - name: Increment testsuite failures attribute

--- a/tasks/set_fact.yml
+++ b/tasks/set_fact.yml
@@ -1,7 +1,7 @@
 - name: Set directory with examples cloned container {{ item }}
   set_fact:
     scl_ex_dir: "{{ testing_dir }}/{{ item }}"
-
 - name: Set directory with cloned upstream SCL container {{ item }}
   set_fact:
     scl_dir: "{{ testing_dir }}/{{ stuff.scl_url }}"
+  when: (stuff.scl_url is defined)

--- a/tasks/verify_in_openshift.yml
+++ b/tasks/verify_in_openshift.yml
@@ -89,4 +89,4 @@
     state: absent
     path: "{{ scl_dir }}"
   changed_when: false
-
+  when: (scl_dir is defined)

--- a/vars/rhel7-dotnet21-container.yml
+++ b/vars/rhel7-dotnet21-container.yml
@@ -1,0 +1,9 @@
+registry_redhat_io: "dotnet/dotnet-21-rhel7"
+tag_name: "2.1"
+deployment: "oc new-app dotnet:2.1~https://github.com/redhat-developer/s2i-dotnetcore-ex#dotnetcore-2.1 --context-dir=app"
+pod_name: "s2i-dotnetcore-ex"
+add_route: true
+check_curl_output: "build ASP.NET apps"
+is_name: "dotnet"
+test_exec_command: "./files/check_oc_exec_output.sh 'dotnet --info'"
+expected_exec_result: "Version: 2.1"

--- a/vars/rhel7-dotnet31-container.yml
+++ b/vars/rhel7-dotnet31-container.yml
@@ -1,0 +1,9 @@
+registry_redhat_io: "dotnet/dotnet-31-rhel7"
+tag_name: "3.1"
+deployment: "oc new-app dotnet:3.1~https://github.com/redhat-developer/s2i-dotnetcore-ex#dotnetcore-3.1 --context-dir=app"
+pod_name: "s2i-dotnetcore-ex"
+add_route: true
+check_curl_output: "Web apps with ASP.NET Core"
+is_name: "dotnet"
+test_exec_command: "./files/check_oc_exec_output.sh 'dotnet --info'"
+expected_exec_result: "Version: 3.1"

--- a/vars/rhel8-dotnet21-container.yml
+++ b/vars/rhel8-dotnet21-container.yml
@@ -1,0 +1,9 @@
+registry_redhat_io: "rhel8/dotnet-21"
+tag_name: "2.1"
+deployment: "oc new-app dotnet:2.1~https://github.com/redhat-developer/s2i-dotnetcore-ex#dotnetcore-2.1 --context-dir=app"
+pod_name: "s2i-dotnetcore-ex"
+add_route: true
+check_curl_output: "build ASP.NET apps"
+is_name: "dotnet"
+test_exec_command: "./files/check_oc_exec_output.sh 'dotnet --info'"
+expected_exec_result: "Version: 2.1"

--- a/vars/rhel8-dotnet31-container.yml
+++ b/vars/rhel8-dotnet31-container.yml
@@ -1,0 +1,9 @@
+registry_redhat_io: "rhel8/dotnet-31"
+tag_name: "3.1"
+deployment: "oc new-app dotnet:3.1~https://github.com/redhat-developer/s2i-dotnetcore-ex#dotnetcore-3.1 --context-dir=app"
+pod_name: "s2i-dotnetcore-ex"
+add_route: true
+check_curl_output: "Web apps with ASP.NET Core"
+is_name: "dotnet"
+test_exec_command: "./files/check_oc_exec_output.sh 'dotnet --info'"
+expected_exec_result: "Version: 3.1"


### PR DESCRIPTION
This will add test cases for .NET Core 2.1 and 3.1 images based on rhel7 and rhel8.

Each test uses oc new-app (so s2i) to deploy the container using our example app:
https://github.com/redhat-developer/s2i-dotnetcore-ex

It also runs dotnet --info inside the container and does a basic version number check (i.e. that the 2.1 container is running 2.1).

To get this to work I had to do a couple of things:
1) By default the current framework assumes that every test wants to clone a repo from sclorg/<repo> and will error if it can't. I made that optional instead of required. If you define an scl_url item in your test var file, then it will try to clone the repo and error if it can't. Otherwise, it just ignores all of that.

2) Despite what the example template said, there was no way to run commands inside the container without writing a custom script for each thing you wanted to run (as is done for the DB check scripts). So I made a generic script that just lets you supply the command that you want to 'oc exec' inside the container and then looks for a substring in the output. Just put your command as a string when you declare test_exec_command. In theory, you can also pass params to the oc exec.
