### PR TITLE
Add the ability to run tests for a specific product version

### DIFF
--- a/README.ocp4
+++ b/README.ocp4
@@ -82,18 +82,32 @@ In order to create a new test go through these steps.
 
 This repo can test Java containers under OpenShift 4 as well.
 
+You can run all versions of Java or a specific one by setting one of the
+values for `ext_test` variable:
+
+* All Java versions: `ext_test=java`
+* Java 8: `ext_test=java_8`
+* Java 11: `ext_test=java_11`
+
 Testing run by a command:
 
-ansible-playbook deploy-and-test.yml -e ext_test=verify_java
+ansible-playbook deploy-and-test.yml -e ext_test=java
 
 or simply by make command:
 ```bash
-make ocp4-tests EXT_TEST=verify_java
+make ocp4-tests EXT_TEST=java
 ```
 
 ## Test dotnet container by ansible-tests in OpenShift
 
 This repo can test Dotnet containers under OpenShift 4 as well.
+
+You can run all versions of Dotnet or a specific one by setting one of the
+values for `ext_test` variable:
+
+* All Dotnet versions: `ext_test=dotnet`
+* Dotnet 21: `ext_test=dotnet_21`
+* Dotnet 31: `ext_test=dotnet_31`
 
 Testing run by a command:
 

--- a/deploy-and-test.yml
+++ b/deploy-and-test.yml
@@ -9,6 +9,18 @@
     xml_file: "{{ testing_dir }}/{{ xml_file_name }}"
     xml_testsuite_path: "/testsuite"
     xml_testcase_path: "{{ xml_testsuite_path }}/testcase"
+    java_8:
+      - java-8-container
+    java_11:
+      - java-11-container
+    java: "{{ java_8 + java_11 }}"
+    dotnet_21:
+      - rhel7-dotnet21-container
+      - rhel8-dotnet21-container
+    dotnet_31:
+      - rhel7-dotnet31-container
+      - rhel8-dotnet31-container
+    dotnet: "{{ dotnet_21 + dotnet_31 }}"
   tasks:
     - name: Check temporary directory and create XML unit file
       block:
@@ -66,17 +78,13 @@
       when: (github_repo is defined) and (github_repo != "") and (ext_test == "")
 
     - name: Check java container
-      include_tasks: ./plugins/{{ ext_test }}.yml
-      loop:
-        - java-8-container
-        - java-11-container
-      when: (ext_test is defined) and (ext_test == "verify_java")
+      include_tasks: ./plugins/verify_java.yml
+      loop: "{{ lookup('vars', ext_test) }}"
+      when: (ext_test is defined) and (ext_test in
+        ["java", "java_8", "java_11"])
 
     - name: Check dotnet containers
       include_tasks: ./tasks/verify_in_openshift.yml
-      loop:
-        - rhel7-dotnet21-container
-        - rhel7-dotnet31-container
-        - rhel8-dotnet21-container
-        - rhel8-dotnet31-container
-      when: (ext_test is defined) and (ext_test == "dotnet")
+      loop: "{{ lookup('vars', ext_test) }}"
+      when: (ext_test is defined) and (ext_test in
+        ["dotnet", "dotnet_21", "dotnet_31"])

--- a/plugins/verify_java.yml
+++ b/plugins/verify_java.yml
@@ -68,6 +68,7 @@
     copy:
       src: "{{ scl_dir }}/test-openjdk/target/surefire-reports/{{ java_item }}"
       dest: "{{ testing_dir }}/java-{{ stuff.version }}-{{ java_item }}"
+      remote_src: yes
     with_items:
       - TEST-com.redhat.xpaas.openjdk.image.DockerImageTest.xml
       - TEST-com.redhat.xpaas.openjdk.maven.MavenJavaArgsTest.xml


### PR DESCRIPTION
This change introduces the ability for the user to be able to run tests for a specific product version (e.g. java or dotnet). This is required for successfully executing interoperability tests for these supported products on OpenShift.

_Run OpenJDK tests for all versions_

`ansible-playbook deploy-and-test.yml -e ext_test=java`

_Run OpenJDK tests for version 11_

`ansible-playbook deploy-and-test.yml -e ext_test=java_11`

_Run OpenJDK tests for version 8_

`ansible-playbook deploy-and-test.yml -e ext_test=java_8`

_Run Dotnet tests for all versions_

`ansible-playbook deploy-and-test.yml -e ext_test=dotnet`

_Run Dotnet tests for version 3.1_

`ansible-playbook deploy-and-test.yml -e ext_test=dotnet_31`

_Run Dotnet tests for version 2.1_

`ansible-playbook deploy-and-test.yml -e ext_test=dotnet_21`

This PR also fixes a bug found where xUnit files are unable to be moved on the targeted host (when the host is a remote machine, not localhost).