### PR TITLE
Save the log directory generated by the java container tests

### DIFF
--- a/plugins/verify_java.yml
+++ b/plugins/verify_java.yml
@@ -77,6 +77,12 @@
     loop_control:
       loop_var: java_item
 
+  - name: Copy log directory to {{ testing_dir }}
+    copy:
+      src: "{{ scl_dir }}/test-openjdk/log"
+      dest: "{{ testing_dir }}/java-{{ stuff.version }}-logs"
+      remote_src: yes
+
 - name: Delete a namespace as soon as tests are finished
   command: "oc delete project xpaasqe"
   register: oc_delete


### PR DESCRIPTION
It has been requested to save the log directory to obtain additional
log files when troubleshooting failed tests. This commit copies the
directory before the clone repository is removed.

(Verification)

```
2022-03-09 17:53:57,033 INFO TASK [Copy xUnit files to /tmp/openjdk_openshift_dir] **************************
2022-03-09 17:53:58,357 INFO changed: [0.0.0.0] => (item=TEST-com.redhat.xpaas.openjdk.image.DockerImageTest.xml)
2022-03-09 17:53:59,444 INFO changed: [0.0.0.0] => (item=TEST-com.redhat.xpaas.openjdk.maven.MavenJavaArgsTest.xml)
2022-03-09 17:54:00,607 INFO changed: [0.0.0.0] => (item=TEST-com.redhat.xpaas.openjdk.opts.JavaMemoryOptionsTest.xml)
2022-03-09 17:54:01,732 INFO changed: [0.0.0.0] => (item=TEST-com.redhat.xpaas.openjdk.s2i.springboot.SpringBootBuildTest.xml)
2022-03-09 17:54:01,741 INFO 
2022-03-09 17:54:01,741 INFO TASK [Copy log directory to /tmp/openjdk_openshift_dir] ************************
2022-03-09 17:54:02,973 INFO changed: [0.0.0.0]
2022-03-09 17:54:02,984 INFO 
2022-03-09 17:54:02,985 INFO TASK [Delete a namespace as soon as tests are finished] ************************
2022-03-09 17:54:04,435 INFO changed: [0.0.0.0]
```

```
.
├── java-17-logs
│   └── log
│       ├── everything.log
│       └── test.log
├── java-17-TEST-com.redhat.xpaas.openjdk.image.DockerImageTest.xml
├── java-17-TEST-com.redhat.xpaas.openjdk.maven.MavenJavaArgsTest.xml
├── java-17-TEST-com.redhat.xpaas.openjdk.opts.JavaMemoryOptionsTest.xml
├── java-17-TEST-com.redhat.xpaas.openjdk.s2i.springboot.SpringBootBuildTest.xml
└── rhscl-testing-results.xml

2 directories, 7 files
```