### PR TITLE
Postgresql-10 reached EOL. Deprecate it.

### DIFF
--- a/deploy-and-test.yml
+++ b/deploy-and-test.yml
@@ -92,7 +92,6 @@
         - rhel8-s2i-python-39-container
         - rhel8-s2i-python-311-container
         - rhel8-s2i-python-312-container
-        - rhel8-postgresql-10-container
         - rhel8-postgresql-12-container
         - rhel8-postgresql-13-container
         - rhel8-postgresql-15-container
@@ -136,7 +135,6 @@
         - rhel8-httpd-ex
         - rhel8-mariadb-105-container
         - rhel8-mariadb-1011-container
-        - rhel8-postgresql-10-container
         - rhel8-postgresql-12-container
         - rhel8-postgresql-13-container
         - rhel8-postgresql-15-container


### PR DESCRIPTION
Postgresql-10 reached EOL for RHEL8 in May 2024.

Let's deprecate it.
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->
