### PR TITLE
Remove Ruby-31 version from testing EOL in March 2025

### DIFF
--- a/deploy-and-test.yml
+++ b/deploy-and-test.yml
@@ -89,7 +89,6 @@
         - rhel8-postgresql-15-container
         - rhel8-postgresql-16-container
         - rhel8-s2i-ruby-25-container
-        - rhel8-s2i-ruby-31-container
         - rhel8-s2i-ruby-33-container
         - rhel8-mysql-80-container
         - rhel8-nginx-ex-122
@@ -112,7 +111,6 @@
         - rhel9-s2i-python-311-container
         - rhel9-s2i-python-312-container
         - rhel9-s2i-ruby-30-container
-        - rhel9-s2i-ruby-31-container
         - rhel9-s2i-ruby-33-container
       when: (github_repo == "") and (ext_test == "")
 
@@ -158,7 +156,6 @@
         - rhel8-s2i-python-311-container
         - rhel8-s2i-python-312-container
         - rhel8-s2i-ruby-25-container
-        - rhel8-s2i-ruby-31-container
         - rhel8-s2i-ruby-33-container
         - rhel9-nodejs-ex-18
         - rhel9-nodejs-ex-18-minimal
@@ -171,7 +168,6 @@
         - rhel9-s2i-python-311-container
         - rhel9-s2i-python-312-container
         - rhel9-s2i-ruby-30-container
-        - rhel9-s2i-ruby-31-container
         - rhel9-s2i-ruby-33-container
       when: (github_repo == "") and (ext_test is defined) and (ext_test == "s2i")
 

--- a/vars/rhel8-s2i-ruby-31-container.yml
+++ b/vars/rhel8-s2i-ruby-31-container.yml
@@ -1,8 +1,0 @@
-registry_redhat_io: "ubi8/ruby-31"
-tag_name: "ruby:3.1-ubi8"
-deployment: "oc new-app ruby:3.1-ubi8~https://github.com/sclorg/s2i-ruby-container.git --name=ruby-example --context-dir=3.1/test/puma-test-app/"
-pod_name: "ruby-example"
-add_route: true
-check_curl_output: "Hello world"
-scl_url: "s2i-ruby-container"
-is_name: "ruby"

--- a/vars/rhel9-s2i-ruby-31-container.yml
+++ b/vars/rhel9-s2i-ruby-31-container.yml
@@ -1,8 +1,0 @@
-registry_redhat_io: "ubi9/ruby-31"
-tag_name: "ruby:3.1-ubi9"
-deployment: "oc new-app ruby:3.1-ubi9~https://github.com/sclorg/s2i-ruby-container.git --context-dir=3.1/test/puma-test-app/"
-pod_name: "s2i-ruby-container"
-add_route: true
-check_curl_output: "Hello world"
-scl_url: "s2i-ruby-container"
-is_name: "ruby"


### PR DESCRIPTION
It reached EOL in March 2025

See https://issues.redhat.com/browse/RHEL-76463


