### PR TITLE
Re-enablement Perl-532 for RHEL8

### DIFF
--- a/deploy-and-test.yml
+++ b/deploy-and-test.yml
@@ -77,6 +77,7 @@
         - rhel8-mariadb-105-container
         - rhel8-mariadb-1011-container
         - rhel8-s2i-perl-526-container
+        - rhel8-s2i-perl-532-container
         - rhel8-s2i-python-36-container
         - rhel8-s2i-python-312-container
         - rhel8-postgresql-12-container
@@ -173,6 +174,7 @@
         - rhel8-cakephp-ex-74
         - rhel8-django-ex-python-36
         - rhel8-s2i-perl-526-container
+        - rhel8-s2i-perl-532-container
         - rhel8-s2i-python-36-container
         - rhel8-s2i-python-312-container
         - rhel8-s2i-ruby-25-container

--- a/vars/rhel8-s2i-perl-532-container.yml
+++ b/vars/rhel8-s2i-perl-532-container.yml
@@ -1,0 +1,8 @@
+registry_redhat_io: "ubi8/perl-532"
+tag_name: "perl:5.32-ubi8"
+deployment: "oc new-app perl:5.32-ubi8~https://github.com/sclorg/dancer-ex.git"
+pod_name: "dancer-ex"
+add_route: true
+check_curl_output: "Welcome to your Dancer application"
+scl_url: "s2i-perl-container"
+is_name: "perl"


### PR DESCRIPTION
<!---

Please review the Contribution Guidelines[1] before submitting the Pull Request.

For more information about the Software Collection Organization, please visit the Welcome pages[2].

[1] https://github.com/sclorg/welcome/blob/master/contribution.md
[2] https://github.com/sclorg/welcome

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended testing pipeline to include RHEL8 S2I Perl container variant, expanding automated test coverage across additional container repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->